### PR TITLE
Use PreparedStatement to prevent SQL injection

### DIFF
--- a/coverity.yaml
+++ b/coverity.yaml
@@ -52,10 +52,10 @@ analyze:
     all: true
     audit: true
     all-security: true
-  cov-analyze-args:
-    - --disable-spotbugs 
-    - --disable 
-    - SIGMA.hardcoded_secret
+#  cov-analyze-args:
+#    - --disable-spotbugs 
+#    - --disable 
+#    - SIGMA.hardcoded_secret
     # - --disable-sigma
   # Specifies which files to analyze when the "analyze.mode" setting is "hfi".
   # Analysis will be performed for only these files.

--- a/src/main/java/com/example/SQL/SQLInjection.java
+++ b/src/main/java/com/example/SQL/SQLInjection.java
@@ -19,13 +19,13 @@ public class SQLInjection {
 		List<String> usernameList = null;
 		try {
 			conn = DriverManager.getConnection("", "", "");
-			String sql = "SELECT username FROM User WHERE id ='" + sqlForUsernames + "'";
-			Statement statement = conn.createStatement();
+			// String sql = "SELECT username FROM User WHERE id ='" + sqlForUsernames + "'";
+			// Statement statement = conn.createStatement();
 			final ResultSet rset = statement.executeQuery(sql);
-			// String sql = "SELECT username FROM User WHERE  id = ?";
-			// PreparedStatement pstatement = conn.prepareStatement(sql);
-			// pstatement.setString(1, sqlForUsernames);
-			// final ResultSet rset = pstatement.executeQuery();
+			String sql = "SELECT username FROM User WHERE  id = ?";
+			PreparedStatement pstatement = conn.prepareStatement(sql);
+			pstatement.setString(1, sqlForUsernames);
+			final ResultSet rset = pstatement.executeQuery();
 			if (rset != null) {
 				usernameList = new ArrayList<String>();
 				while (rset.next()) {


### PR DESCRIPTION
Refactored SQL query to use PreparedStatement for better security against SQL injection.